### PR TITLE
Explain toga source install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Current Packages Supported:
 
 ## Install
 
+#### YAPI Install
+
 To use YAPI you need to clone this repository:
 
     git clone https://github.com/Wabri/YAPI.git
@@ -57,6 +59,26 @@ Or use the short method with the name of the package you want to install:
 
     ./yapi.sh install <package_name>
 
+#### GUI Install
+
+To install toga for the gui, you need to install from source.
+
+    git clone https://github.com/pybee/toga.git
+    cd toga
+    pip install -e src/core
+    pip install -e src/dummy
+
+The next line depends on the operating system in use. For windows, the command is:
+
+    pip install -e src/winforms
+
+The command to install on MacOs is:
+
+    pip install -e src/cocoa
+
+The command to install on Linux is:
+
+    pip install -e src/gtk
 
 ****
 


### PR DESCRIPTION
Toga is using features that require an install from source until the next version is released.  This closes issues #37 